### PR TITLE
Support 0x04040404 for supportsInterface function

### DIFF
--- a/src/DN404Mirror.sol
+++ b/src/DN404Mirror.sol
@@ -295,8 +295,8 @@ contract DN404Mirror {
         /// @solidity memory-safe-assembly
         assembly {
             let s := shr(224, interfaceId)
-            // ERC165: 0x01ffc9a7, ERC721: 0x80ac58cd, ERC721Metadata: 0x5b5e139f.
-            result := or(or(eq(s, 0x01ffc9a7), eq(s, 0x80ac58cd)), eq(s, 0x5b5e139f))
+            // ERC165: 0x01ffc9a7, ERC721: 0x80ac58cd, ERC721Metadata: 0x5b5e139f, DN404: 0x04040404.
+            result := or(or(eq(s, 0x01ffc9a7), eq(s, 0x80ac58cd)), eq(s, 0x5b5e139f), eq(s, 0x04040404))
         }
     }
 


### PR DESCRIPTION
## Description

Would be great if we could support 0x04040404 as an identifier for DN404 contracts, so that the contract could automatically call setSkipNFT before transfer, etc.

## Checklist

Ensure you completed **all of the steps** below before submitting your pull request:

- [x] Ran `forge fmt`?
- [x] Ran `forge snapshot`?
- [x] Ran `forge test`?

_Pull requests with an incomplete checklist will be thrown out._